### PR TITLE
Delete and Udate Available Meals functionality

### DIFF
--- a/src/components/DeleteMeal.js
+++ b/src/components/DeleteMeal.js
@@ -1,15 +1,44 @@
-import React from 'react';
-import meal1 from '../img/meals/meal1.jpg';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import Navigation from './navigation/Navigation';
+import {
+  getAllMeals, deleteMeal, removeMeal, updateAvailability, updateWhenAvailable,
+} from '../features/admin/adminSlice';
 
 const DeleteMeal = () => {
-  const meals = [
-    {
-      id: 1,
-      title: 'Meal 1',
-      image: meal1,
-    },
-  ];
+  const allMeals = useSelector((state) => state.meals.allMeals);
+  const isLoading = useSelector((state) => state.meals.isLoading);
+  const isError = useSelector((state) => state.meals.isError);
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getAllMeals());
+  }, [dispatch]);
+
+  const handleDeleteMeal = (mealId) => {
+    dispatch(removeMeal(mealId));
+    dispatch(deleteMeal(mealId));
+  };
+
+  const updateAvailabilityOfMeals = (mealId, available) => {
+    const newAvailability = !available;
+    dispatch(updateWhenAvailable({ id: mealId, available: newAvailability }));
+    dispatch(updateAvailability({ id: mealId, available: newAvailability }));
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (isError) {
+    return (
+      <div>
+        Error:
+        {isError}
+      </div>
+    );
+  }
 
   return (
     <div className="h-screen flex justify-between">
@@ -17,18 +46,26 @@ const DeleteMeal = () => {
       <div className="container mx-auto mt-8 ml-10 p-10">
         <h1 className="text-2xl font-bold mb-10">My Meals(s):</h1>
         <div className="flex flex-col">
-          {meals.map((meal) => (
+          {allMeals.map((meal) => (
             <div key={meal.id} className="bg-white rounded-lg shadow-md border-gray-300 border p-7 mr-1 mb-4 flex items-center justify-between">
-              <img src={meal.image} alt={meal.title} className="w-16 h-16 object-cover rounded mr-4" />
-              <h2 className="text-lg font-semibold flex-grow text-center">{meal.title}</h2>
-              <button type="button" className="bg-red-500 text-white py-2 px-4 mr-4 rounded">Available</button>
-              <button type="button" className="bg-red-500 text-white py-2 px-4 rounded">Delete</button>
-
+              <img src={meal.photo} alt={meal.name} className="w-16 h-16 object-cover rounded mr-4" />
+              <h2 className="text-lg font-semibold flex-grow text-center">{meal.name}</h2>
+              {meal.available ? (
+                <button type="button" onClick={() => updateAvailabilityOfMeals(meal.id, meal.available)} className="bg-red-500 text-white py-2 px-4 mr-4 rounded">
+                  Not Available
+                </button>
+              ) : (
+                <button type="button" onClick={() => updateAvailabilityOfMeals(meal.id, meal.available)} className="bg-green text-white py-2 px-4 mr-4 rounded">
+                  Available
+                </button>
+              )}
+              <button type="button" onClick={() => handleDeleteMeal(meal.id)} className="bg-red-500 text-white py-2 px-4 mr-4 rounded">
+                Delete
+              </button>
             </div>
           ))}
         </div>
       </div>
-      <button type="button" className="bg-green text-white py-2 px-4 absolute rounded bottom-10 right-10">Reserve</button>
     </div>
   );
 };

--- a/src/components/navigation/MealSlider.js
+++ b/src/components/navigation/MealSlider.js
@@ -102,7 +102,14 @@ function MealSlider() {
           {meals.map((meal) => (
             <div key={meal.id} className="meal-card flex items-center justify-center text-center">
               <Link to={`/meals/${meal.id}`} className="flex justify-items-center align-items-center">
-                <img src={meal.photo} alt="meal1" className="m-auto p-auto w-64 rounded-full hover:cursor-pointer" />
+                <img
+                  src={meal.photo}
+                  alt="meal1"
+                  className="m-auto p-auto rounded-full hover:cursor-pointer"
+                  style={{ width: '200px', height: '200px', objectFit: 'cover' }}
+                />
+                {' '}
+
               </Link>
               <div className="text-center my-6">
                 <p className="font-bold my-2 uppercase hover:cursor-pointer">{meal.name}</p>

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -28,7 +28,7 @@ function Navigation() {
           <li className="w-full hover:bg-green active:bg-green hover:text-white p-2"><Link to="/reservation" className="">Reserve</Link></li>
           <li className="w-full hover:bg-green active:bg-green hover:text-white p-2"><Link to="/myReservations" className="">My Reservations</Link></li>
           {isAdmin && (<li className="w-full hover:bg-green active:bg-green hover:text-white p-2"><Link to="/addmeal" className="">Add meal</Link></li>)}
-          <li className="w-full hover:bg-green active:bg-green hover:text-white p-2"><Link to="/deleteMeal" className="">Delete meal</Link></li>
+          {isAdmin && (<li className="w-full hover:bg-green active:bg-green hover:text-white p-2"><Link to="/deleteMeal" className="">Delete meal</Link></li>)}
           <li className="w-full hover:bg-green active:bg-green hover:text-white p-2">
             <button type="button" onClick={handleLogout} className="cursor-pointer">
               Logout

--- a/src/features/admin/adminSlice.js
+++ b/src/features/admin/adminSlice.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 
 const initialState = {
   meals: [],
+  allMeals: [],
   isLoading: false,
   isError: '',
 };
@@ -42,11 +43,81 @@ export const getMeals = createAsyncThunk('meals/getMeals', async (_, thunkAPI) =
     return thunkAPI.rejectWithValue(error.response.data);
   }
 });
+export const getAllMeals = createAsyncThunk('meals/getAllMeals', async (_, thunkAPI) => {
+  try {
+    const token = localStorage.getItem('access_token');
+
+    const response = await axios.get('http://127.0.0.1:4000/meals_available', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    return response.data;
+  } catch (error) {
+    return thunkAPI.rejectWithValue(error.response.data);
+  }
+});
+export const deleteMeal = createAsyncThunk('meals/deleteMeals', async (id, thunkAPI) => {
+  try {
+    const token = localStorage.getItem('access_token');
+
+    const response = await axios.delete(`http://127.0.0.1:4000/api/v1/meals/${id}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    return response.data;
+  } catch (error) {
+    return thunkAPI.rejectWithValue(error.response.data);
+  }
+});
+
+export const updateAvailability = createAsyncThunk(
+  'meals/updateAvailabilityOfMeals',
+  async ({ id, available }, thunkAPI) => {
+    try {
+      const token = localStorage.getItem('access_token');
+
+      const response = await axios.patch(
+        `http://127.0.0.1:4000/api/v1/meals/${id}/update_availability`,
+        { available }, // Pass the available parameter in the request body
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+
+      return response.data;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.response.data);
+    }
+  },
+);
 
 const mealsSlice = createSlice({
   name: 'meals',
   initialState,
-  reducers: {},
+  reducers: {
+    removeMeal: (state, action) => {
+      const deletedMealId = action.payload;
+      state.allMeals = state.allMeals.filter((meal) => meal.id !== deletedMealId);
+    },
+    updateWhenAvailable: (state, action) => {
+      const { id, available } = action.payload;
+      state.allMeals = state.allMeals.map((meal) => {
+        if (meal.id === id) {
+          return {
+            ...meal,
+            available,
+          };
+        }
+        return meal;
+      });
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(getMeals.pending, (state) => {
@@ -61,6 +132,18 @@ const mealsSlice = createSlice({
         state.isLoading = false;
         state.isError = action.payload;
       })
+      .addCase(getAllMeals.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(getAllMeals.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.isError = '';
+        state.allMeals = action.payload;
+      })
+      .addCase(getAllMeals.rejected, (state, action) => {
+        state.isLoading = false;
+        state.isError = action.payload;
+      })
       .addCase(addMeal.fulfilled, (state, action) => {
         state.isLoading = false;
         state.isError = '';
@@ -69,8 +152,26 @@ const mealsSlice = createSlice({
       .addCase(addMeal.rejected, (state, action) => {
         state.isLoading = false;
         state.isError = action.error.message;
+      })
+      .addCase(deleteMeal.fulfilled, (state) => {
+        state.isLoading = false;
+        state.isError = '';
+      })
+      .addCase(deleteMeal.rejected, (state, action) => {
+        state.isLoading = false;
+        state.isError = action.error.message;
+      })
+      .addCase(updateAvailability.fulfilled, (state) => {
+        state.isLoading = false;
+        state.isError = '';
+      })
+      .addCase(updateAvailability.rejected, (state) => {
+        state.isLoading = false;
+        state.isError = '';
       });
   },
 });
+export const { removeMeal } = mealsSlice.actions;
+export const { updateWhenAvailable } = mealsSlice.actions;
 
 export default mealsSlice.reducer;


### PR DESCRIPTION
In this PR, I have implemented the following features:

- Fetching all meals from the API.
- Restricting the delete meal button in the navigation to only be visible to admins.
- Allowing only admins to delete meals and update their availability (mark as available or not).
- When an admin marks a meal as available by clicking a button, the meal will be accessible to all users on the meals page. Conversely, when an admin marks a meal as not available, it will not be accessible to regular users, except for the admin.